### PR TITLE
fix: semantic-release config and hatchling build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "justin"
@@ -77,10 +77,11 @@ Homepage = "https://github.com/djachenko/justin"
 "Source Code" = "https://github.com/djachenko/justin"
 
 [tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+branch = "master"
+commit_message = "chore(release): v{version} [no ci]"
 major_on_zero = false
-
-[tool.setuptools.packages.find]
-where = ["src"]
+allow_zero_version = true
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ Homepage = "https://github.com/djachenko/justin"
 "Bug Tracker" = "https://github.com/djachenko/justin/issues"
 "Source Code" = "https://github.com/djachenko/justin"
 
+[tool.semantic_release]
+major_on_zero = false
+
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
## Summary

- Switch build backend to `hatchling` (aligned with repokit template)
- Add full `[tool.semantic_release]` config: `version_toml`, `branch`, `commit_message`, `major_on_zero = false`, `allow_zero_version = true`

These commits were pushed to `chore/repokit-setup` after the PR was merged, so they didn't make it into master — causing the release workflow to bump to `1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)