### PR TITLE
fix: retry upload batch on non-API errors (504 with HTML body)

### DIFF
--- a/src/justin/typer/upload_command.py
+++ b/src/justin/typer/upload_command.py
@@ -654,7 +654,10 @@ class UploadCommand(DestinationsAwareCommand, EventUtils):
                 print("Error, retrying this particular batch")
 
                 continue
-            except Exception:
+            except json.JSONDecodeError:
+                # pu.vk.com periodically returns HTTP 504 with an HTML body instead of JSON;
+                # requests.Response.json() then raises JSONDecodeError instead of ApiError,
+                # so it isn't caught by the except ApiError above. Treat it the same way: retry the batch.
                 print("Error, retrying this particular batch")
                 continue
 

--- a/src/justin/typer/upload_command.py
+++ b/src/justin/typer/upload_command.py
@@ -648,12 +648,12 @@ class UploadCommand(DestinationsAwareCommand, EventUtils):
             try:
                 uploaded_photos = album.add_photos([file.path for file in not_uploaded_files[:batch_size]])
             except ApiError as e:
-                if e.code == 100:
-                    print("Error, retrying this particular batch")
+                if e.code != 100:
+                    raise
 
-                    continue
+                print("Error, retrying this particular batch")
 
-                raise
+                continue
             except json.JSONDecodeError:
                 # pu.vk.com periodically returns HTTP 504 with an HTML body instead of JSON;
                 # requests.Response.json() then raises JSONDecodeError instead of ApiError,

--- a/src/justin/typer/upload_command.py
+++ b/src/justin/typer/upload_command.py
@@ -648,12 +648,12 @@ class UploadCommand(DestinationsAwareCommand, EventUtils):
             try:
                 uploaded_photos = album.add_photos([file.path for file in not_uploaded_files[:batch_size]])
             except ApiError as e:
-                if e.code != 100:
-                    raise
+                if e.code == 100:
+                    print("Error, retrying this particular batch")
 
-                print("Error, retrying this particular batch")
+                    continue
 
-                continue
+                raise
             except json.JSONDecodeError:
                 # pu.vk.com periodically returns HTTP 504 with an HTML body instead of JSON;
                 # requests.Response.json() then raises JSONDecodeError instead of ApiError,

--- a/src/justin/typer/upload_command.py
+++ b/src/justin/typer/upload_command.py
@@ -654,6 +654,9 @@ class UploadCommand(DestinationsAwareCommand, EventUtils):
                 print("Error, retrying this particular batch")
 
                 continue
+            except Exception:
+                print("Error, retrying this particular batch")
+                continue
 
             uploaded_count = len(uploaded_photos)
 


### PR DESCRIPTION
## Summary
- VK upload server (`pu.vk.com`) periodically returns HTTP 504 with an HTML body instead of JSON, causing `JSONDecodeError` and crashing the upload.
- The retry loop in `__get_album` only caught `ApiError`. Added a catch-all `except Exception` so transient errors retry the batch instead of crashing.

## Test plan
- [ ] Run `justin upload` on a set that previously hit 504 and confirm it retries instead of crashing