### PR TITLE
refactor: use cached_property instead of property+cache in DI

### DIFF
--- a/src/justin/actions/manage_tags_action.py
+++ b/src/justin/actions/manage_tags_action.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from argparse import Namespace
 from dataclasses import make_dataclass, dataclass
-from functools import cache
+from functools import cache, cached_property
 from typing import Type, List
 
 from justin.cms_2.storage.google_sheets.google_sheets_database import Link
@@ -22,8 +22,7 @@ class PostStrategy:
 
         self.__context = context
 
-    @property
-    @cache
+    @cached_property
     def tags(self) -> List[Tag]:
         sqlite_tags = self.__context.sqlite_cms.get_tags()
         sqlite_tags.sort(
@@ -33,8 +32,7 @@ class PostStrategy:
 
         return sqlite_tags
 
-    @property
-    @cache
+    @cached_property
     def context(self) -> Context:
         return self.__context
 
@@ -114,8 +112,7 @@ class ScheduledStrategy(PostStrategy):
     def group(self) -> Group:
         return self.context.default_group
 
-    @property
-    @cache
+    @cached_property
     def scheduled_posts(self) -> List[VKPost]:
         return self.group.get_scheduled_posts()
 

--- a/src/justin/actions/rearrange_action.py
+++ b/src/justin/actions/rearrange_action.py
@@ -1,7 +1,7 @@
 import random
 from argparse import Namespace
 from datetime import timedelta, datetime
-from functools import cache
+from functools import cached_property
 from typing import List
 
 from justin.actions.group_action import GroupAction
@@ -14,8 +14,7 @@ from pyvko.entities.user import Group
 class RearrangeAction(GroupAction):
     DEFAULT_STEP = 1
 
-    @property
-    @cache
+    @cached_property
     def parameters(self) -> List[Parameter]:
         return super().parameters + [
             Parameter("--step", type=int, default=RearrangeAction.DEFAULT_STEP),

--- a/src/justin/cms/people_cms.py
+++ b/src/justin/cms/people_cms.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from dataclasses import dataclass
 from datetime import date
-from functools import cache
+from functools import cached_property
 from pathlib import Path
 from typing import Dict, Callable
 
@@ -182,8 +182,7 @@ class PeopleRegistry(JsonTable[PersonEntry, str]):
 
 
 class PeopleCMS(BaseCMS, ABC, FixPeopleMixin):
-    @property
-    @cache
+    @cached_property
     def people(self) -> Table[PersonEntry, str]:
         people = PeopleRegistry(self.root / "people.json")
 
@@ -191,8 +190,7 @@ class PeopleCMS(BaseCMS, ABC, FixPeopleMixin):
 
         return people
 
-    @property
-    @cache
+    @cached_property
     def people_migrations(self) -> Table[PersonMigrationEntry, str]:
         migrations = JsonTable(self.root / "people_migrations.json", PersonMigrationEntry, lambda x: x.src)
 

--- a/src/justin/cms_2/storage/google_sheets/google_sheets_database.py
+++ b/src/justin/cms_2/storage/google_sheets/google_sheets_database.py
@@ -1,6 +1,6 @@
 import webbrowser
 from dataclasses import dataclass, fields
-from functools import cache
+from functools import cached_property
 from pathlib import Path
 from typing import Type, List, Dict, Callable, TypeVar
 
@@ -86,8 +86,7 @@ class GoogleSheetsDatabase:
         self.__sheets: Dict[str, GoogleSheetsDatabase.Sheet] | None = None
         self.__root = root
 
-    @property
-    @cache
+    @cached_property
     def __spreadsheets(self):
         token_path = self.__root / "token.json"
         creds = None

--- a/src/justin/di/app.py
+++ b/src/justin/di/app.py
@@ -1,4 +1,4 @@
-from functools import cache
+from functools import cached_property
 
 from lazy_object_proxy import Proxy
 
@@ -17,13 +17,11 @@ class DI:
 
         setup_metafiles()
 
-    @property
-    @cache
+    @cached_property
     def __hooks_factory(self):
         return HooksFactory()
 
-    @property
-    @cache
+    @cached_property
     def stages_factory(self) -> StagesFactory:
         return StagesFactory(
             self.__checks_factory,

--- a/src/justin/shared/models/exif.py
+++ b/src/justin/shared/models/exif.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from datetime import datetime
-from functools import cache
+from functools import cached_property
 from pathlib import Path
 from typing import Iterable
 
@@ -23,8 +23,7 @@ class PillowExif(Exif):
 
     __reverse_mapping = {v: k for k, v in ExifTags.TAGS.items()}
 
-    @property
-    @cache
+    @cached_property
     def date_taken(self) -> datetime:
         return datetime.strptime(
             self.__get_tag_value("DateTimeOriginal") or self.__get_tag_value("DateTime"),
@@ -49,8 +48,7 @@ class PillowExif(Exif):
 class NativeExif(Exif):
     from exif import Image
 
-    @property
-    @cache
+    @cached_property
     def date_taken(self) -> datetime:
         if hasattr(self.source_exif, "datetime_original"):
             return datetime.strptime(

--- a/src/justin/shared/models/photoset_migration.py
+++ b/src/justin/shared/models/photoset_migration.py
@@ -1,6 +1,6 @@
 import json
 from abc import abstractmethod, ABC
-from functools import cache
+from functools import cache, cached_property
 from typing import Iterable, Tuple, List
 from uuid import UUID
 
@@ -108,8 +108,7 @@ class RenameFoldersMigration(PhotosetMigration, ABC):
 
 
 class ChangeStructureMigration(RenameFoldersMigration):
-    @property
-    @cache
+    @cached_property
     def renamings(self) -> Iterable[Tuple[str, str]]:
         return [
             ("our_people", "my_people",),

--- a/src/justin/shared/models/sources.py
+++ b/src/justin/shared/models/sources.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from functools import cache
+from functools import cached_property
 from pathlib import Path
 from typing import List, Iterable
 
@@ -84,8 +84,7 @@ class InternalMetadataSource(Source):
     def files(self) -> List[File]:
         return [self.__file]
 
-    @property
-    @cache
+    @cached_property
     def exif(self) -> Exif:
         return parse_exif(self.__file.path)
 
@@ -123,8 +122,7 @@ class ExternalMetadataSource(Source):
     def name(self):
         return self.raw.stem
 
-    @property
-    @cache
+    @cached_property
     def exif(self) -> Exif:
         return parse_exif(self.raw.path)
 

--- a/src/justin/shared/world.py
+++ b/src/justin/shared/world.py
@@ -3,7 +3,7 @@ import platform
 import shutil
 import string
 from abc import abstractmethod
-from functools import cache
+from functools import cache, cached_property
 from pathlib import Path
 from typing import List, Iterable, Type
 
@@ -49,8 +49,7 @@ class Location:
 
         self.__folder = folder
 
-    @property
-    @cache
+    @cached_property
     def __metafile(self) -> LocationMetafile:
         return LocationMetafile.get(self.__folder)
 

--- a/src/justin/typer/base_commands/pattern_command.py
+++ b/src/justin/typer/base_commands/pattern_command.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC
-from functools import cache
+from functools import cached_property
 from pathlib import Path
 from typing import Iterable, Dict, Any
 
@@ -16,8 +16,7 @@ class PatternCommand(ABC):
     SET_NAME = "set_name"
     PART_FULL_NAME = "part_full_name"
 
-    @property
-    @cache
+    @cached_property
     def extra(self) -> Extra:
         return frozendict()
 


### PR DESCRIPTION
## Summary
- `@property @cache` combo leaks memory: `functools.cache` holds a permanent reference to `self` via the wrapped function's cache, so instances never get collected.
- Replaced with `@cached_property` everywhere this pattern appears (not just `di/` — audited the whole repo): `di/app.py`, `shared/world.py`, `cms/people_cms.py`, `cms_2/storage/google_sheets/google_sheets_database.py`, `shared/models/photoset_migration.py`, `shared/models/sources.py`, `shared/models/exif.py`, `typer/base_commands/pattern_command.py`, `actions/manage_tags_action.py`, `actions/rearrange_action.py`.
- Left bare `@cache` (no `@property`) alone — different semantics (memoized method, not cached attribute), out of scope.

## Test plan
- [ ] mypy/ruff pass
- [ ] Spot-check overrides that call `super().<cached_property>` (e.g. `UploadCommand.extra`, `RenamePeopleMigration.renamings`) still resolve correctly