### PR TITLE
refactor: move hardcoded spreadsheet_id from app.py into Config

### DIFF
--- a/src/justin/shared/config.py
+++ b/src/justin/shared/config.py
@@ -14,6 +14,8 @@ class Config:
     my_people_url: str
     cullen_url: str
 
+    spreadsheet_id: str
+
     photoset_structure: Structure
     # disk_structure: Structure
 

--- a/src/justin/typer/app/app.py
+++ b/src/justin/typer/app/app.py
@@ -46,14 +46,14 @@ def build_app(config_path: Path) -> Typer:
     cms = CMS(cms_root)
     sqlite_cms = SQLiteCMS(cms_root)
 
-    sheets_db = GoogleSheetsDatabase(
-        spreadsheet_id="1wpjgMa8PIsi7uVzkVG9G1Q_kP_lOnCgbBLKzZYssKzc",
-        root=google_sheets_root
-    )
-
     config = Config.from_source(configs_folder / __CONFIG_FILE, init_globals={
         "names": sqlite_cms.get_all_folders(),
     })
+
+    sheets_db = GoogleSheetsDatabase(
+        spreadsheet_id=config.spreadsheet_id,
+        root=google_sheets_root
+    )
 
     di = DI(config)
 


### PR DESCRIPTION
## Summary
- `GoogleSheetsDatabase` spreadsheet_id was hardcoded in `typer/app/app.py`.
- Added `spreadsheet_id: str` field to `Config`, sourced from `~/.justin/config.py` (local config, not in repo) instead.
- Reordered `build_app` so `Config` is loaded before constructing `GoogleSheetsDatabase`.

## Test plan
- [ ] Run any `justin` command that touches the sheets-backed CMS, confirm it still resolves the same spreadsheet