### PR TITLE
chore: ignore _worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ src/justin/cms_2/sub_cms/tmplt_cms.py
 
 memory/
 .repokit
+
+_worktrees/


### PR DESCRIPTION
Adds `_worktrees/` to .gitignore for the worktree skill convention (`_worktrees/<type>/<name>`).